### PR TITLE
Added module.exports

### DIFF
--- a/Software/NodeJS/libs/sensors/genericDigitalInputSensor.js
+++ b/Software/NodeJS/libs/sensors/genericDigitalInputSensor.js
@@ -10,3 +10,5 @@ GenericDigitalInputSensor.prototype = new DigitalSensor()
 GenericDigitalInputSensor.prototype.read = function() {
     return DigitalSensor.prototype.read.call(this)
 }
+
+module.exports = GenericDigitalInputSensor

--- a/Software/NodeJS/libs/sensors/genericDigitalOutputSensor.js
+++ b/Software/NodeJS/libs/sensors/genericDigitalOutputSensor.js
@@ -26,3 +26,5 @@ GenericDigitalOutputSensor.prototype.off = function() {
       return false
   }
 }
+
+module.exports = GenericDigitalOutputSensor


### PR DESCRIPTION
Were these missing?

You can now do:
`var DigitalOutput = GrovePi.sensors.DigitalOutput;
var led = new DigitalOutput(4);
led.on();
led.off();`
