### PR TITLE
Updated for stability and documentation

### DIFF
--- a/Software/NodeJS/libs/sensors/GroveLCDRGBDisplay.js
+++ b/Software/NodeJS/libs/sensors/GroveLCDRGBDisplay.js
@@ -2,20 +2,10 @@
  * Class definition to interact with the Grove LCD RGB Display
  * Original code in Python - https://github.com/DexterInd/GrovePi/blob/master/Software/Python/grove_rgb_lcd/grove_rgb_lcd.py
  * 
- * I2C Definition - https://en.wikipedia.org/wiki/I%C2%B2C
- *
- * ARBITRATION ON I2C - 
- * Although conceptually a single-master bus, a slave device that supports the "host notify protocol" acts as a master to perform the notification. 
- * It seizes the bus and writes a 3-byte message to the reserved "SMBus Host" address (0x08), passing its address and two bytes of data. When two 
- * slaves try to notify the host at the same time, one of them will lose arbitration and need to retry.  
+ * I2C Definition: https://en.wikipedia.org/wiki/I%C2%B2C
+ * I2C Bus Specification: http://www.nxp.com/documents/user_manual/UM10204.pdf
+ * LCD Datasheet - Hitachi HD44780: https://www.sparkfun.com/datasheets/LCD/HD44780.pdf
  * 
- * An alternative slave notification system uses the separate SMBALERT# signal to request attention. In this case, the host performs a 1-byte read 
- * from the reserved "SMBus Alert Response Address" (0x0c), which is a kind of broadcast address. All alerting slaves respond with a data bytes 
- * containing their own address. When the slave successfully transmits its own address (winning arbitration against others) it stops raising that interrupt. 
- * In both this and the preceding case, arbitration ensures that one slave's message will be received, and the others will know they must retry.
- * 
- * There seems to be an issue if you change the color and then set text with the I2C bus synchronous writes.  Modified to 
- * change the code to write text first and then set the display color.
  * 
  * @Author: Salvatore Castro
  * @Date: February 20,2017
@@ -25,8 +15,8 @@
 
 const sleep     = require('sleep');
 
-const DISPLAY_RGB_ADDR  = 0x62;
-const DISPLAY_TEXT_ADDR = 0x3e;
+const DISPLAY_RGB_ADDR  = 0x62; // 6 = 0110, 2 = 0010
+const DISPLAY_TEXT_ADDR = 0x3e; // 3 = 0011, e = 1110
 
 // Red    ==> Red = 255, Green = 0,   Blue = 0
 // Yellow ==> Red = 255, Green = 255, Blue = 0
@@ -48,8 +38,36 @@ var GroveLCDRGBDisplay = class GroveLCDRGBDisplay {
 //		console.log("constructor");
 		this.i2c = i2c;
 //		console.log("I2C 1 - Set: "+this.i2c);
+		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0,0); // Backlight Initialization
+		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,1,0); // Disable cursor blinking (ie Blinky mode)
+
+		// https://www.sparkfun.com/datasheets/LCD/HD44780.pdf on page #23 on Instruction Register
+		// when the address counter is 08H, the cursor position is displayed at DDRAM address 0x08.
+		// 
+		// Flags for function set derrived from C code here: https://github.com/Seeed-Studio/Grove_LCD_RGB_Backlight/blob/master/rgb_lcd.h and rgb_lcd.cpp
+		// Flags are all set but I can't find documentation on this 
+		// +------------------ 0x8_ (1___) - ?
+		// |+----------------- 0x4_ (_1__) - ?
+		// ||+---------------- 0x2_ (__1_) - ?
+		// |||+--------------- 0x1_ (___1) - ?
+		// ||||
+		// |||| +------------- 0x08 (1___) - ?
+		// |||| |+------------ 0x04 (_1__) - ?
+		// |||| ||+----------- 0x02 (__1_) - ?
+		// |||| |||+---------- 0x01 (___1) - ?
+		// 1111 1111 == 0xff
+		// Data flags set here are 0xff in .cpp and 0xaa in python
+		// REG_OUTPUT == 0x08 
+		// REG_OUTPUT -> Set LEDs controllable by both PWM and GRPPWM registers 
+		//this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0x08,0xaa); // To Character Generator (CG) Addr -> LCD_DISPLAYCONTROL 0x08, 0xaa = 1010 1010 ==> Original in Python
+		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0x08,0xff); // I can't find documentation on this...in the referenced .cpp; differs from python but doesn't appear to impact the display
 	}
-	
+
+	/**
+	 * Usefull for callback commands that you just want to print out completed
+	 *
+	 *	@param	input	The string to echo out to the console display
+	 */
 	echo(input) {
 		console.log("Echo: "+input);
 		return input;
@@ -63,21 +81,14 @@ var GroveLCDRGBDisplay = class GroveLCDRGBDisplay {
 	 * @param b	Blue
 	 */
 	setRGB(r, g, b) {
-		//sleep.msleep(50);
-		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0,0);
-		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,1,0);
-		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0x08,0xaa); // The reserved "SMBus Host" address (0x08)
+//		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0x08,0xff); // To Character Generator (CG) Addr 0x62 -> LCD_DISPLAYCONTROL 0x08, 0xaa = 1010 1010
 		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,4,r);
 		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,3,g);
 		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,2,b);
 	}
 
 	setRGBAry(rgb) {
-		//sleep.msleep(50);
 		//console.log("setRGB: "+rgb);
-		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0,0);
-		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,1,0);
-		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,0x08,0xaa); // The reserved "SMBus Host" address (0x08)
 		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,4,rgb[0]);
 		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,3,rgb[1]);
 		this.i2c.writeByteSync(DISPLAY_RGB_ADDR,2,rgb[2]);
@@ -89,7 +100,14 @@ var GroveLCDRGBDisplay = class GroveLCDRGBDisplay {
 	 * @param cmd	Command sent to the LCD
 	 */
 	textCommand(cmd) {
-		this.i2c.writeByteSync(DISPLAY_TEXT_ADDR, 0x80, cmd);
+		// Every now and then the synch write fails with an I/O Bus error...need to wait and then retry
+		try {
+			this.i2c.writeByteSync(DISPLAY_TEXT_ADDR, 0x80, cmd); // To Text -> LCD SET Display Data RAM ADDR 0x80 -> command byte
+		} catch (err) {
+			sleep.msleep(5);
+			this.i2c.writeByteSync(DISPLAY_TEXT_ADDR, 0x80, cmd); // To Text -> LCD SET Display Data RAM ADDR 0x80 -> command byte
+			console.log("GroveLCDRGBDisplay.setText.textCommand exception caught: "+err);
+		}
 	}
 
 	/**
@@ -103,14 +121,11 @@ var GroveLCDRGBDisplay = class GroveLCDRGBDisplay {
 	 * @param text	Text that displays on the LCD panel
 	 */
 	setText(text) {
-		this.i2c.writeByteSync(DISPLAY_TEXT_ADDR,0,0);
-		this.i2c.writeByteSync(DISPLAY_TEXT_ADDR,1,0);
-		this.i2c.writeByteSync(DISPLAY_TEXT_ADDR,0x08,0xaa); // The reserved "SMBus Host" address (0x08)
-		this.textCommand(0x01);        // clear display
-		sleep.msleep(50);
-		this.textCommand(0x08 | 0x04); // display on(8 = 1000) and no cursor(4 = 0100)...could just use 0x0c (c=1100)
-		this.textCommand(0x28);
-		sleep.msleep(50);
+		this.textCommand(0x01); // clear display - LCD_CLEARDISPLAY 0x01s
+		sleep.msleep(5);
+		this.textCommand(0x08 | 0x04); // Display Control (LCD_DISPLAYCONTROL 8 = 1000) ==> LCD_MOVERIGHT Entry Mode (LCD_ENTRYMODESET 4 = 0100)...could just use 0x0c (c=1100)
+		this.textCommand(0x20 | 0x08); // Function set (LCD_FUNCTIONSET 2 = 0010)  ==>   LCD_2LINE Display Control (LCD_DISPLAYCONTROL 8 = 1000)...could just use 0x28
+		sleep.msleep(5);
 		var count = 0;
 		var row = 0;
 		for (var i = 0, len = text.length; i < len; i++) {
@@ -119,15 +134,22 @@ var GroveLCDRGBDisplay = class GroveLCDRGBDisplay {
 				row++;
 				if (row === 2)
 					break;
-				this.textCommand(0xc0)
+				// See page #12 in HD44780.pdf for documentation on this for the 2-line display
+				this.textCommand(0xc0) // Move cursor to the next line --- col = (row == 0 ? col|0x80 : col|0xc0); unsigned char dta[2] = {0x80, col}; 8 (1000),  c (1100)
 				if (text[i] === '\n')
 					continue;
 			}
 			count++;
-			this.i2c.writeByteSync(DISPLAY_TEXT_ADDR, 0x40, text[i].charCodeAt(0));
+			// Every now and then the synch write fails with an I/O Bus error...need to wait and then retry
+			try {
+				this.i2c.writeByteSync(DISPLAY_TEXT_ADDR, 0x40, text[i].charCodeAt(0)); // LCD SET Character Generator ADDR 0x40 -> Character Byte
+			} catch (err) {
+				sleep.msleep(5);
+				this.i2c.writeByteSync(DISPLAY_TEXT_ADDR, 0x40, text[i].charCodeAt(0)); // LCD SET Character Generator ADDR 0x40 -> Character Byte
+				console.log("GroveLCDRGBDisplay.setText.setText exception caught: "+err);
+			}
 		}
 	}
-
 
 	/**
 	 *  Reset the display to only show the display message; useful on exit of program
@@ -138,10 +160,10 @@ var GroveLCDRGBDisplay = class GroveLCDRGBDisplay {
 	}
 
 	/**
-	 *  Reset the display and turn off LED light useful on termination
+	 *  Reset the display to only show the display message; useful on exit of program
 	 */
 	turnOffDisplay() {
-		this.textCommand(0x01); // clear display
+		this.textCommand(0x01); // clear display - LCD_CLEARDISPLAY 0x01s
 		//sleep.msleep(50);
 		this.setRGBAry(colorBlack);
 	}	


### PR DESCRIPTION
I still am not sure of the actual purpose of the write to the display address (0x62) for Data Register 0x08 the value of 0xff or 0xaa that happens on lines 62 & 63.  The code is there in the .py (writes 0xaa) and .cpp (writes 0xff) referenced examples but the documentation isn't clear enough to explain it's purpose.  I found the datasheet but nothing specific for these flags that I could decipher from it.  The LCD datasheet (PDF) is here: https://www.sparkfun.com/datasheets/LCD/HD44780.pdf